### PR TITLE
feat/stability-error-handling

### DIFF
--- a/docs/Errors.md
+++ b/docs/Errors.md
@@ -1,0 +1,17 @@
+# Error Handling
+
+This project distinguishes between three primary error types:
+
+| Type | Description | Handling |
+| ---- | ----------- | -------- |
+| **User Error** | Validation or input issues caused by the user. | Report via toast, allow correction. |
+| **Network Error** | Connectivity problems or timeouts. | `apiService` retries with exponential backoff and surfaces a toast. |
+| **System Error** | Unexpected server or code failures. | Logged via `handleError` and caught by React `ErrorBoundary`. |
+
+## Layer Responsibilities
+
+- **API Layer** (`src/services/apiService.js`): wraps all network and Supabase calls with timeouts, retries and cancellation via `AbortController`.
+- **Components & Pages**: catch service errors, call `handleError` for structured logging and user toasts.
+- **React Error Boundaries**: `ErrorBoundary` at the app root and route level prevents UI crashes and shows fallback UI.
+
+For new code, always route data calls through `apiService`, surface a toast on failure, and let errors bubble to Error Boundaries.

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -50,9 +50,11 @@ const PageLoader = () => (
 
 // Wrapper component for lazy-loaded pages
 const LazyPage = ({ children }) => (
-  <Suspense fallback={<PageLoader />}>
-    {children}
-  </Suspense>
+  <ErrorBoundary>
+    <Suspense fallback={<PageLoader />}>
+      {children}
+    </Suspense>
+  </ErrorBoundary>
 );
 
 const router = createBrowserRouter([

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -1,6 +1,14 @@
 // Centralized API service for consistent error handling and retries
 import { supabase } from '../supabaseClient';
 
+class ApiError extends Error {
+  constructor(message, type = 'system') {
+    super(message);
+    this.name = 'ApiError';
+    this.type = type;
+  }
+}
+
 class ApiService {
   constructor() {
     this.defaultTimeout = 10000; // 10 seconds
@@ -8,29 +16,33 @@ class ApiService {
     this.retryDelay = 1000; // 1 second
   }
 
-  // Generic retry mechanism
+  // Generic retry mechanism with exponential backoff
   async withRetry(operation, maxRetries = this.maxRetries) {
     let lastError;
-    
+
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         return await operation();
       } catch (error) {
         lastError = error;
-        
+
         // Don't retry on auth errors or client errors
-        if (error.message?.includes('401') || error.message?.includes('403') || 
-            error.message?.includes('Invalid') || error.name === 'AbortError') {
+        if (
+          error.message?.includes('401') ||
+          error.message?.includes('403') ||
+          error.message?.includes('invalid') ||
+          error.name === 'AbortError'
+        ) {
           throw error;
         }
-        
+
         if (attempt < maxRetries) {
-          await this.delay(this.retryDelay * attempt);
+          await this.delay(this.retryDelay * 2 ** (attempt - 1));
           continue;
         }
       }
     }
-    
+
     throw lastError;
   }
 
@@ -46,7 +58,7 @@ class ApiService {
     } catch (error) {
       clearTimeout(timeoutId);
       if (error.name === 'AbortError') {
-        throw new Error('Request timed out. Please check your connection and try again.');
+        throw new ApiError('Request timed out. Please check your connection and try again.', 'network');
       }
       throw error;
     }
@@ -55,65 +67,80 @@ class ApiService {
   // Generic Supabase query wrapper
   async executeQuery(queryBuilder, options = {}) {
     const { timeout = this.defaultTimeout, retries = this.maxRetries } = options;
-    
+
     return this.withRetry(async () => {
       return this.withTimeout(async (signal) => {
         const query = queryBuilder();
         if (signal) {
           query.abortSignal(signal);
         }
-        
+
         const { data, error } = await query;
-        
+
         if (error) {
-          throw new Error(error.message);
+          throw new ApiError(error.message, 'system');
         }
-        
+
         return data;
+      }, timeout);
+    }, retries);
+  }
+
+  // Fetch wrapper with retry, timeout, and abort support
+  async fetchWithRetry(url, options = {}, config = {}) {
+    const { timeout = this.defaultTimeout, retries = this.maxRetries } = config;
+
+    return this.withRetry(async () => {
+      return this.withTimeout(async (signal) => {
+        const response = await fetch(url, { ...options, signal });
+        if (!response.ok) {
+          const text = await response.text();
+          throw new ApiError(text || `Request failed with ${response.status}`, 'network');
+        }
+        const contentType = response.headers.get('content-type') || '';
+        if (contentType.includes('application/json')) {
+          return response.json();
+        }
+        return response.text();
       }, timeout);
     }, retries);
   }
 
   // Utility delay function
   delay(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   // Check if error is retryable
   isRetryableError(error) {
-    const retryableMessages = [
-      'network',
-      'timeout',
-      'connection',
-      'temporary',
-      'unavailable'
-    ];
-    
+    const retryableMessages = ['network', 'timeout', 'connection', 'temporary', 'unavailable'];
+
     const errorMessage = error.message?.toLowerCase() || '';
-    return retryableMessages.some(msg => errorMessage.includes(msg));
+    return retryableMessages.some((msg) => errorMessage.includes(msg));
   }
 
   // Format error for user display
   formatError(error) {
     if (typeof error === 'string') return error;
-    
+
     // Handle specific Supabase errors
     if (error.code === 'PGRST116') {
       return 'Record not found';
     }
-    
+
     if (error.code?.startsWith('23')) {
       return 'A database constraint was violated. Please check your input.';
     }
-    
+
     // Handle network errors
-    if (error.name === 'AbortError') {
+    if (error.name === 'AbortError' || error.type === 'network') {
       return 'Request timed out. Please try again.';
     }
-    
+
     // Default to error message or generic message
     return error.message || 'An unexpected error occurred. Please try again.';
   }
 }
 
 export const apiService = new ApiService();
+export { ApiError };

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -1,0 +1,10 @@
+import { showToast } from './toast';
+
+export const logError = (error, context = {}) => {
+  console.error('Error:', { message: error.message, stack: error.stack, context });
+};
+
+export const handleError = (error, userMessage = 'An unexpected error occurred.') => {
+  logError(error);
+  showToast(userMessage);
+};

--- a/src/utils/toast.js
+++ b/src/utils/toast.js
@@ -1,0 +1,8 @@
+export const showToast = (message) => {
+  if (typeof window !== 'undefined' && window.alert) {
+    // Simple placeholder toast implementation
+    window.alert(message);
+  } else {
+    console.log('Toast:', message);
+  }
+};


### PR DESCRIPTION
## Summary
- add centralized API client with retries and timeouts
- wrap routes in error boundaries and document error taxonomy
- guard profile loading with isMounted and structured error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: import/no-unresolved for Deno modules in supabase functions)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c3b597e1548330926db5c17cb8b487