### PR TITLE
Preserve song selection order and restore set drag-and-drop

### DIFF
--- a/src/components/SongSelectorModal.jsx
+++ b/src/components/SongSelectorModal.jsx
@@ -14,7 +14,7 @@ const SongSelectorModal = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage] = useState(10);
-  const [localSelectedSongs, setLocalSelectedSongs] = useState(new Set());
+  const [localSelectedSongs, setLocalSelectedSongs] = useState([]);
 
   // Configure Fuse.js for fuzzy search
   const searchResults = useMemo(() => {
@@ -52,7 +52,7 @@ const SongSelectorModal = ({
   useEffect(() => {
     // Reset local selection when modal opens
     if (isOpen) {
-      setLocalSelectedSongs(new Set());
+      setLocalSelectedSongs([]);
       setSearchQuery('');
       setCurrentPage(1);
     }
@@ -73,17 +73,23 @@ const SongSelectorModal = ({
   };
 
   const handleSongToggle = (song) => {
-    const newSelected = new Set(localSelectedSongs);
-    if (newSelected.has(song.id)) {
-      newSelected.delete(song.id);
-    } else {
-      newSelected.add(song.id);
-    }
-    setLocalSelectedSongs(newSelected);
+    setLocalSelectedSongs(prev => {
+      const alreadySelectedIndex = prev.indexOf(song.id);
+
+      if (alreadySelectedIndex !== -1) {
+        const updated = [...prev];
+        updated.splice(alreadySelectedIndex, 1);
+        return updated;
+      }
+
+      return [...prev, song.id];
+    });
   };
 
   const handleAddSelected = () => {
-    const selectedSongObjects = songs.filter(song => localSelectedSongs.has(song.id));
+    const selectedSongObjects = localSelectedSongs
+      .map(id => songs.find(song => song.id === id))
+      .filter(Boolean);
     onSongsSelected(selectedSongObjects);
     onClose();
   };
@@ -115,19 +121,19 @@ const SongSelectorModal = ({
                 <div>
                   <h3 className="text-lg font-medium text-zinc-100">Add Songs</h3>
                   <p className="text-sm text-zinc-400">
-                    {localSelectedSongs.size > 0 && `${localSelectedSongs.size} selected • `}
+                    {localSelectedSongs.length > 0 && `${localSelectedSongs.length} selected • `}
                     {searchResults.length} songs available
                   </p>
                 </div>
               </div>
               <div className="flex items-center space-x-3">
-                {localSelectedSongs.size > 0 && (
+                {localSelectedSongs.length > 0 && (
                   <button
                     onClick={handleAddSelected}
                     className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors font-medium"
                   >
                     <Plus size={16} className="mr-2" />
-                    Add {localSelectedSongs.size} Song{localSelectedSongs.size !== 1 ? 's' : ''}
+                    Add {localSelectedSongs.length} Song{localSelectedSongs.length !== 1 ? 's' : ''}
                   </button>
                 )}
                 <button
@@ -173,7 +179,7 @@ const SongSelectorModal = ({
               <div className="space-y-2">
                 {currentSongs.map((song) => {
                   const alreadySelected = isAlreadySelected(song.id);
-                  const locallySelected = localSelectedSongs.has(song.id);
+                  const locallySelected = localSelectedSongs.includes(song.id);
 
                   return (
                     <div
@@ -268,13 +274,13 @@ const SongSelectorModal = ({
             >
               Cancel
             </button>
-            {localSelectedSongs.size > 0 && (
+            {localSelectedSongs.length > 0 && (
               <button
                 onClick={handleAddSelected}
                 className="inline-flex items-center px-6 py-2 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors font-medium"
               >
                 <Plus size={16} className="mr-2" />
-                Add {localSelectedSongs.size} Song{localSelectedSongs.size !== 1 ? 's' : ''}
+                Add {localSelectedSongs.length} Song{localSelectedSongs.length !== 1 ? 's' : ''}
               </button>
             )}
           </div>

--- a/src/pages/SetDetailPage.jsx
+++ b/src/pages/SetDetailPage.jsx
@@ -4,7 +4,7 @@ import { Edit, ArrowLeft, Music } from 'lucide-react';
 import { usePageTitle } from '../context/PageTitleContext';
 import { setsService } from '../services/setsService';
 import { setlistsService } from '../services/setlistsService';
-import MobileDragDrop from '../components/MobileDragDrop';
+import DraggableList from '../components/DraggableList';
 
 const SetDetailPage = () => {
   const { setlistId, setId } = useParams();
@@ -184,7 +184,7 @@ const SetDetailPage = () => {
             </button>
           </div>
         ) : (
-          <MobileDragDrop
+          <DraggableList
             items={songs}
             onReorder={handleReorderSongs}
             onRemove={handleRemoveSong}

--- a/src/pages/SetFormPage.jsx
+++ b/src/pages/SetFormPage.jsx
@@ -1,15 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Save, XCircle, Music, Trash2, GripVertical, BookTemplate as Collection } from 'lucide-react';
+import { Save, XCircle, Music, BookTemplate as Collection } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { usePageTitle } from '../context/PageTitleContext';
 import { setsService } from '../services/setsService';
 import { songCollectionsService } from '../services/songCollectionsService';
-import SongSelector from '../components/SongSelector';
 import SongSelectorModal from '../components/SongSelectorModal';
 import CollectionSelectorModal from '../components/CollectionSelectorModal';
 import DuplicateModal from '../components/DuplicateModal';
 import CollectionDuplicateModal from '../components/CollectionDuplicateModal';
+import DraggableList from '../components/DraggableList';
 
 const SetFormPage = () => {
   const { setlistId, setId } = useParams();
@@ -345,38 +345,18 @@ const SetFormPage = () => {
 
         <div className="space-y-4">
           {setSongs.length === 0 ? (
-          <div className="text-center py-8">
-            <Music className="mx-auto h-12 w-12 text-slate-400 mb-4" />
-            <p className="text-slate-300 text-lg mb-2">No songs in set</p>
-            <p className="text-slate-400">Add songs to build your set</p>
-          </div>
+            <div className="text-center py-8">
+              <Music className="mx-auto h-12 w-12 text-slate-400 mb-4" />
+              <p className="text-slate-300 text-lg mb-2">No songs in set</p>
+              <p className="text-slate-400">Add songs to build your set</p>
+            </div>
           ) : (
-          <div className="space-y-2">
-            {setSongs.map((song, index) => (
-              <div
-                key={`${song.id}-${index}`}
-                className="flex items-center justify-between p-4 bg-slate-700 rounded-lg border border-slate-600"
-              >
-                <div className="flex items-center space-x-3">
-                  <GripVertical className="h-5 w-5 text-slate-400 cursor-move" />
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-slate-100 truncate">
-                      {song.title}
-                    </p>
-                    <p className="text-sm text-slate-400 truncate">
-                      {song.original_artist} {song.key_signature && `• ${song.key_signature}`}
-                    </p>
-                  </div>
-                </div>
-                <button
-                  onClick={() => handleRemoveSong(index)}
-                  className="p-2 text-red-400 hover:text-red-300 transition-colors"
-                >
-                  <Trash2 size={16} />
-                </button>
-              </div>
-            ))}
-          </div>
+            <DraggableList
+              items={setSongs}
+              onReorder={handleReorderSongs}
+              onRemove={handleRemoveSong}
+              type="songs"
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- track the exact selection order in the song selector modal so added songs keep their chosen order
- swap set management views to the shared DraggableList component to support drag/drop reordering and removal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddcf242b108330972ac9fb46dbbc03