### PR TITLE
Improve duplicate handling and collection drag-and-drop

### DIFF
--- a/src/components/DuplicateModal.jsx
+++ b/src/components/DuplicateModal.jsx
@@ -6,17 +6,14 @@ const DuplicateModal = ({ isOpen, onClose, duplicates = [], onRemoveDuplicates, 
 
   const handleRemoveDuplicates = () => {
     onRemoveDuplicates();
-    onClose();
   };
 
   const handleKeepInCurrent = () => {
     onKeepInCurrentSet();
-    onClose();
   };
 
   const handleKeepInOriginal = () => {
     onKeepInOriginalSet();
-    onClose();
   };
 
   return (
@@ -38,7 +35,7 @@ const DuplicateModal = ({ isOpen, onClose, duplicates = [], onRemoveDuplicates, 
                 </h3>
                 <div className="mt-2">
                   <p className="text-base sm:text-sm text-gray-500 dark:text-gray-400 mb-4">
-                    The following songs already exist in other {type === 'set' ? 'sets within this setlist' : 'locations'}:
+                    The following songs already exist in other {type === 'set' ? 'sets within this setlist' : 'locations'}. Choose how you would like to resolve each duplicate so this {type === 'set' ? 'set' : 'collection'} can be saved.
                   </p>
                   <div className="max-h-40 overflow-y-auto scroll-container">
                     {duplicates.map((duplicate, index) => (
@@ -66,14 +63,14 @@ const DuplicateModal = ({ isOpen, onClose, duplicates = [], onRemoveDuplicates, 
                   onClick={handleKeepInCurrent}
                   className="w-full sm:w-auto inline-flex justify-center rounded-xl border border-transparent shadow-sm px-4 py-3 sm:py-2 bg-blue-600 text-base sm:text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 mobile-form-button"
                 >
-                  Keep in Current Set
+                  Keep in This Set (remove from others)
                 </button>
                 <button
                   type="button"
                   onClick={handleKeepInOriginal}
                   className="w-full sm:w-auto inline-flex justify-center rounded-xl border border-gray-300 dark:border-slate-600 shadow-sm px-4 py-3 sm:py-2 bg-white dark:bg-slate-800 text-base sm:text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 mobile-form-button"
                 >
-                  Keep in Original Set
+                  Keep in Existing Set(s)
                 </button>
               </>
             )}
@@ -82,7 +79,7 @@ const DuplicateModal = ({ isOpen, onClose, duplicates = [], onRemoveDuplicates, 
               onClick={handleRemoveDuplicates}
               className="w-full sm:w-auto inline-flex justify-center rounded-xl border border-transparent shadow-sm px-4 py-3 sm:py-2 bg-red-600 text-base sm:text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 mobile-form-button"
             >
-              Remove Duplicates
+              Remove from All Sets
             </button>
             <button
               type="button"

--- a/src/components/SongSelectorModal.jsx
+++ b/src/components/SongSelectorModal.jsx
@@ -14,7 +14,7 @@ const SongSelectorModal = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage] = useState(10);
-  const [localSelectedSongs, setLocalSelectedSongs] = useState(new Set());
+  const [localSelectedSongs, setLocalSelectedSongs] = useState([]);
 
   // Configure Fuse.js for fuzzy search
   const searchResults = useMemo(() => {
@@ -52,7 +52,7 @@ const SongSelectorModal = ({
   useEffect(() => {
     // Reset local selection when modal opens
     if (isOpen) {
-      setLocalSelectedSongs(new Set());
+      setLocalSelectedSongs([]);
       setSearchQuery('');
       setCurrentPage(1);
     }
@@ -73,17 +73,23 @@ const SongSelectorModal = ({
   };
 
   const handleSongToggle = (song) => {
-    const newSelected = new Set(localSelectedSongs);
-    if (newSelected.has(song.id)) {
-      newSelected.delete(song.id);
-    } else {
-      newSelected.add(song.id);
-    }
-    setLocalSelectedSongs(newSelected);
+    setLocalSelectedSongs(prev => {
+      const alreadySelectedIndex = prev.indexOf(song.id);
+
+      if (alreadySelectedIndex !== -1) {
+        const updated = [...prev];
+        updated.splice(alreadySelectedIndex, 1);
+        return updated;
+      }
+
+      return [...prev, song.id];
+    });
   };
 
   const handleAddSelected = () => {
-    const selectedSongObjects = songs.filter(song => localSelectedSongs.has(song.id));
+    const selectedSongObjects = localSelectedSongs
+      .map(id => songs.find(song => song.id === id))
+      .filter(Boolean);
     onSongsSelected(selectedSongObjects);
     onClose();
   };
@@ -115,19 +121,19 @@ const SongSelectorModal = ({
                 <div>
                   <h3 className="text-lg font-medium text-zinc-100">Add Songs</h3>
                   <p className="text-sm text-zinc-400">
-                    {localSelectedSongs.size > 0 && `${localSelectedSongs.size} selected • `}
+                    {localSelectedSongs.length > 0 && `${localSelectedSongs.length} selected • `}
                     {searchResults.length} songs available
                   </p>
                 </div>
               </div>
               <div className="flex items-center space-x-3">
-                {localSelectedSongs.size > 0 && (
+                {localSelectedSongs.length > 0 && (
                   <button
                     onClick={handleAddSelected}
                     className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors font-medium"
                   >
                     <Plus size={16} className="mr-2" />
-                    Add {localSelectedSongs.size} Song{localSelectedSongs.size !== 1 ? 's' : ''}
+                    Add {localSelectedSongs.length} Song{localSelectedSongs.length !== 1 ? 's' : ''}
                   </button>
                 )}
                 <button
@@ -173,7 +179,7 @@ const SongSelectorModal = ({
               <div className="space-y-2">
                 {currentSongs.map((song) => {
                   const alreadySelected = isAlreadySelected(song.id);
-                  const locallySelected = localSelectedSongs.has(song.id);
+                  const locallySelected = localSelectedSongs.includes(song.id);
 
                   return (
                     <div
@@ -268,13 +274,13 @@ const SongSelectorModal = ({
             >
               Cancel
             </button>
-            {localSelectedSongs.size > 0 && (
+            {localSelectedSongs.length > 0 && (
               <button
                 onClick={handleAddSelected}
                 className="inline-flex items-center px-6 py-2 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors font-medium"
               >
                 <Plus size={16} className="mr-2" />
-                Add {localSelectedSongs.size} Song{localSelectedSongs.size !== 1 ? 's' : ''}
+                Add {localSelectedSongs.length} Song{localSelectedSongs.length !== 1 ? 's' : ''}
               </button>
             )}
           </div>

--- a/src/pages/SetDetailPage.jsx
+++ b/src/pages/SetDetailPage.jsx
@@ -4,7 +4,7 @@ import { Edit, ArrowLeft, Music } from 'lucide-react';
 import { usePageTitle } from '../context/PageTitleContext';
 import { setsService } from '../services/setsService';
 import { setlistsService } from '../services/setlistsService';
-import MobileDragDrop from '../components/MobileDragDrop';
+import DraggableList from '../components/DraggableList';
 
 const SetDetailPage = () => {
   const { setlistId, setId } = useParams();
@@ -184,7 +184,7 @@ const SetDetailPage = () => {
             </button>
           </div>
         ) : (
-          <MobileDragDrop
+          <DraggableList
             items={songs}
             onReorder={handleReorderSongs}
             onRemove={handleRemoveSong}

--- a/src/services/setsService.js
+++ b/src/services/setsService.js
@@ -76,7 +76,12 @@ export const setsService = {
 
     // Check for duplicates within the setlist (across all sets)
     if (songs && songs.length > 0) {
-      const duplicates = await this.checkForDuplicatesInSetlist(setlist_id, songs.map(s => s.song_id));
+      const duplicates = await this.checkForDuplicatesInSetlist(
+        setlist_id,
+        songs.map(s => s.song_id),
+        null,
+        true
+      );
       if (duplicates.length > 0) {
         throw new Error(JSON.stringify({
           type: 'DUPLICATES_FOUND',
@@ -155,9 +160,10 @@ export const setsService = {
     // Check for duplicates within the setlist (across all sets) excluding current set
     if (songs !== undefined && songs.length > 0) {
       const duplicates = await this.checkForDuplicatesInSetlist(
-        existingSet.setlist_id, 
+        existingSet.setlist_id,
         songs.map(s => s.song_id),
-        id // Exclude current set from duplicate check
+        id, // Exclude current set from duplicate check
+        true
       );
       if (duplicates.length > 0) {
         throw new Error(JSON.stringify({


### PR DESCRIPTION
## Summary
- add a duplicate resolution flow to the set editor so songs can be kept in the current set, existing sets, or removed entirely
- normalize song ordering after edits and reuse the draggable list for collection forms and detail views
- fetch duplicate metadata when saving sets to power the resolution modal messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddcf242b108330972ac9fb46dbbc03